### PR TITLE
Build time dependency checking on pybind module files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ syntax: glob
 *.C
 *.log
 *.silo
+*_stamp.cmake
 *.job
 *.job.out
 job.out*

--- a/cmake/CMakeBasics.cmake
+++ b/cmake/CMakeBasics.cmake
@@ -22,18 +22,21 @@ function(instantiate _inst_var _source_var)
   foreach(_inst ${${_inst_var}})
     if(ENABLE_INSTANTIATIONS)
       foreach(_dim ${_dims})
+        #set(_inst_py ${_inst}Inst.cc.py)
         set(_inst_py ${CMAKE_CURRENT_SOURCE_DIR}/${_inst}Inst.cc.py)
         set(_inst_file ${_inst}Inst${_dim}d.cc)
         add_custom_command(
+          #OUTPUT  ${_inst_file}
           OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/${_inst_file}
           COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/helpers/InstantiationGenerator.py ${_inst_py} ${_inst_file} ${_dim}
-          MAIN_DEPENDENCY ${_inst_py}
+          #MAIN_DEPENDENCY ${_inst_py}
           BYPRODUCTS ${_inst_file}
-          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+          #WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
           COMMENT "Generating instantiation ${_inst_file}...")
 
         # Add the instantiation files to the sources.
-        list(APPEND _tmp_source ${CMAKE_CURRENT_BINARY_DIR}/${_inst_file})
+        #list(APPEND _tmp_source ${CMAKE_CURRENT_BINARY_DIR}/${_inst_file})
+        list(APPEND _tmp_source ${_inst_file})
       endforeach()
     else()
       # If the base source file exists, add it to the source files.

--- a/cmake/InstallLibraries.cmake
+++ b/cmake/InstallLibraries.cmake
@@ -164,6 +164,7 @@ set(PIPTARGETS
   cython
   sobol
   scipy
+  pipreqs
   )
 
 if(PYTHON_DIR)

--- a/cmake/Modules/UsePYB11Generator.cmake
+++ b/cmake/Modules/UsePYB11Generator.cmake
@@ -104,6 +104,12 @@ macro(PYB11_GENERATE_BINDINGS)
     )
   STRING(REPLACE ";" "<->" PYTHON_ENV_STR ${PYTHON_ENV})
 
+  execute_process(COMMAND env PYTHONPATH=\"${PYTHON_ENV_STR}\"
+                  ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/helpers/moduleCheck.py 
+                  ${PROJECT_SOURCE_DIR}/Pybind11Wraps/${PYB11_MODULE_NAME}/${PYB11_SOURCE}
+                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Pybind11Wraps/${PYB11_MODULE_NAME}
+                  OUTPUT_VARIABLE MODULE_DEPENDS)
+
   add_custom_command(
     OUTPUT Spheral${PYB11_GENERATED_SOURCE} ${PYB11_GENERATED_HEADER}
     COMMAND env PYTHONPATH=\"${PYTHON_ENV_STR}\"
@@ -111,6 +117,6 @@ macro(PYB11_GENERATE_BINDINGS)
     'from PYB11Generator import * \; 
     import ${PYB11_MODULE_NAME}MOD \;
     PYB11generateModule(${PYB11_MODULE_NAME}MOD, \"Spheral${PYB11_MODULE_NAME}\") '
-    DEPENDS ${PYB11_SOURCE}
+    DEPENDS ${MODULE_DEPENDS} ${PYB11_SOURCE}
     )
 endmacro()

--- a/cmake/Modules/UsePYB11Generator.cmake
+++ b/cmake/Modules/UsePYB11Generator.cmake
@@ -115,7 +115,7 @@ macro(PYB11_GENERATE_BINDINGS)
 
   include(${CMAKE_CURRENT_SOURCE_DIR}/${PYB11_MODULE_NAME}_stamp.cmake)
 
-  add_custom_target(${PYB11_MODULE_NAME}_STAMP_GENERATION ALL
+  add_custom_target(${PYB11_MODULE_NAME}_stamp ALL
                     COMMAND env PYTHONPATH=\"${PYTHON_ENV_STR}\"
                     ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/helpers/moduleCheck.py
                     ${PYB11_MODULE_NAME}
@@ -130,6 +130,6 @@ macro(PYB11_GENERATE_BINDINGS)
     'from PYB11Generator import * \; 
     import ${PYB11_MODULE_NAME}MOD \;
     PYB11generateModule(${PYB11_MODULE_NAME}MOD, \"Spheral${PYB11_MODULE_NAME}\") '
-    DEPENDS ${PYB11_MODULE_NAME}_STAMP_GENERATION ${${PYB11_MODULE_NAME}_DEPENDS} ${PYB11_SOURCE}
+    DEPENDS ${PYB11_MODULE_NAME}_stamp ${${PYB11_MODULE_NAME}_DEPENDS} ${PYB11_SOURCE}
     )
 endmacro()

--- a/cmake/Modules/UsePYB11Generator.cmake
+++ b/cmake/Modules/UsePYB11Generator.cmake
@@ -104,12 +104,22 @@ macro(PYB11_GENERATE_BINDINGS)
     )
   STRING(REPLACE ";" "<->" PYTHON_ENV_STR ${PYTHON_ENV})
 
-  execute_process(COMMAND env PYTHONPATH=\"${PYTHON_ENV_STR}\"
-                  ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/helpers/moduleCheck.py 
-                  ${PROJECT_SOURCE_DIR}/Pybind11Wraps/${PYB11_MODULE_NAME}/${PYB11_SOURCE}
-                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Pybind11Wraps/${PYB11_MODULE_NAME}
-                  OUTPUT_VARIABLE MODULE_DEPENDS)
 
+  add_custom_target(${PYB11_MODULE_NAME}_MODULE ALL
+                      COMMAND env PYTHONPATH=\"${PYTHON_ENV_STR}\"
+                      ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/helpers/moduleCheck.py 
+                      ${PROJECT_SOURCE_DIR}/Pybind11Wraps/${PYB11_MODULE_NAME}/${PYB11_SOURCE}
+                      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Pybind11Wraps/${PYB11_MODULE_NAME}
+                      )
+  #add_custom_command(OUTPUT ${PYB11_MODULE_NAME}_MODULE
+  #  execute_process(
+  #                    COMMAND env PYTHONPATH=\"${PYTHON_ENV_STR}\"
+  #                    ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/helpers/moduleCheck.py 
+  #                    ${PROJECT_SOURCE_DIR}/Pybind11Wraps/${PYB11_MODULE_NAME}/${PYB11_SOURCE}
+  #                    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Pybind11Wraps/${PYB11_MODULE_NAME}
+  #                    OUTPUT_VARIABLE ${PYB11_MODULE_NAME}_MODULE
+  #                    )
+  #
   add_custom_command(
     OUTPUT Spheral${PYB11_GENERATED_SOURCE} ${PYB11_GENERATED_HEADER}
     COMMAND env PYTHONPATH=\"${PYTHON_ENV_STR}\"
@@ -117,6 +127,7 @@ macro(PYB11_GENERATE_BINDINGS)
     'from PYB11Generator import * \; 
     import ${PYB11_MODULE_NAME}MOD \;
     PYB11generateModule(${PYB11_MODULE_NAME}MOD, \"Spheral${PYB11_MODULE_NAME}\") '
-    DEPENDS ${MODULE_DEPENDS} ${PYB11_SOURCE}
+    #DEPENDS ${MODULE_DEPENDS} ${PYB11_SOURCE}
+    DEPENDS ${${PYB11_MODULE_NAME}_MODULE} ${PYB11_SOURCE}
     )
 endmacro()

--- a/cmake/Modules/UsePYB11Generator.cmake
+++ b/cmake/Modules/UsePYB11Generator.cmake
@@ -103,31 +103,34 @@ macro(PYB11_GENERATE_BINDINGS)
     "${PROJECT_SOURCE_DIR}/SimulationControl:"
     )
   STRING(REPLACE ";" "<->" PYTHON_ENV_STR ${PYTHON_ENV})
+  message("${CMAKE_CURRENT_SOURCE_DIR}")
 
+  if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${PYB11_MODULE_NAME}_stamp.cmake")
+    execute_process(COMMAND env PYTHONPATH=\"${PYTHON_ENV_STR}\"
+                    ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/helpers/moduleCheck.py 
+                    ${PYB11_MODULE_NAME}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${PYB11_SOURCE}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    )
+  endif()
 
-  add_custom_target(${PYB11_MODULE_NAME}_MODULE ALL
-                      COMMAND env PYTHONPATH=\"${PYTHON_ENV_STR}\"
-                      ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/helpers/moduleCheck.py 
-                      ${PROJECT_SOURCE_DIR}/Pybind11Wraps/${PYB11_MODULE_NAME}/${PYB11_SOURCE}
-                      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Pybind11Wraps/${PYB11_MODULE_NAME}
-                      )
-  #add_custom_command(OUTPUT ${PYB11_MODULE_NAME}_MODULE
-  #  execute_process(
-  #                    COMMAND env PYTHONPATH=\"${PYTHON_ENV_STR}\"
-  #                    ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/helpers/moduleCheck.py 
-  #                    ${PROJECT_SOURCE_DIR}/Pybind11Wraps/${PYB11_MODULE_NAME}/${PYB11_SOURCE}
-  #                    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Pybind11Wraps/${PYB11_MODULE_NAME}
-  #                    OUTPUT_VARIABLE ${PYB11_MODULE_NAME}_MODULE
-  #                    )
-  #
+  include(${CMAKE_CURRENT_SOURCE_DIR}/${PYB11_MODULE_NAME}_stamp.cmake)
+
+  add_custom_target(${PYB11_MODULE_NAME}_STAMP_GENERATION ALL
+                    COMMAND env PYTHONPATH=\"${PYTHON_ENV_STR}\"
+                    ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/helpers/moduleCheck.py
+                    ${PYB11_MODULE_NAME}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${PYB11_SOURCE}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    )
+
   add_custom_command(
-    OUTPUT Spheral${PYB11_GENERATED_SOURCE} ${PYB11_GENERATED_HEADER}
+    OUTPUT Spheral${PYB11_GENERATED_SOURCE}
     COMMAND env PYTHONPATH=\"${PYTHON_ENV_STR}\"
     ${PYTHON_EXECUTABLE} -c
     'from PYB11Generator import * \; 
     import ${PYB11_MODULE_NAME}MOD \;
     PYB11generateModule(${PYB11_MODULE_NAME}MOD, \"Spheral${PYB11_MODULE_NAME}\") '
-    #DEPENDS ${MODULE_DEPENDS} ${PYB11_SOURCE}
-    DEPENDS ${${PYB11_MODULE_NAME}_MODULE} ${PYB11_SOURCE}
+    DEPENDS ${PYB11_MODULE_NAME}_STAMP_GENERATION ${${PYB11_MODULE_NAME}_DEPENDS} ${PYB11_SOURCE}
     )
 endmacro()

--- a/cmake/Modules/UsePYB11Generator.cmake
+++ b/cmake/Modules/UsePYB11Generator.cmake
@@ -103,7 +103,6 @@ macro(PYB11_GENERATE_BINDINGS)
     "${PROJECT_SOURCE_DIR}/SimulationControl:"
     )
   STRING(REPLACE ";" "<->" PYTHON_ENV_STR ${PYTHON_ENV})
-  message("${CMAKE_CURRENT_SOURCE_DIR}")
 
   if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${PYB11_MODULE_NAME}_stamp.cmake")
     execute_process(COMMAND env PYTHONPATH=\"${PYTHON_ENV_STR}\"

--- a/src/helpers/moduleCheck.py
+++ b/src/helpers/moduleCheck.py
@@ -1,7 +1,5 @@
 from modulefinder import ModuleFinder
 import sys
-import os
-import imp
 
 finder = ModuleFinder()
 finder.run_script(sys.argv[1])

--- a/src/helpers/moduleCheck.py
+++ b/src/helpers/moduleCheck.py
@@ -1,0 +1,14 @@
+from modulefinder import ModuleFinder
+import sys
+import os
+import imp
+
+finder = ModuleFinder()
+finder.run_script(sys.argv[1])
+
+out = ""
+for name, mod in finder.modules.iteritems():
+  if (mod.__file__):
+    if not ("lib/python2.7" in mod.__file__):
+      out = out + mod.__file__ + ";"
+print out

--- a/src/helpers/moduleCheck.py
+++ b/src/helpers/moduleCheck.py
@@ -1,12 +1,32 @@
 from modulefinder import ModuleFinder
-import sys
+import sys, os
+import filecmp
+
+mod_name = sys.argv[1]
+mod_file = sys.argv[2]
 
 finder = ModuleFinder()
-finder.run_script(sys.argv[1])
+finder.run_script(mod_file)
 
-out = ""
+current_stamp_name = mod_name + "_stamp.cmake"
+tmp_stamp_name = current_stamp_name + ".tmp"
+
+newF = open(tmp_stamp_name, "w")
+newF.write("set("+mod_name+"_DEPENDS \n")
+
 for name, mod in finder.modules.iteritems():
   if (mod.__file__):
     if not ("lib/python2.7" in mod.__file__):
-      out = out + mod.__file__ + ";"
-print out
+      newF.write(mod.__file__)
+      newF.write('\n')
+
+newF.write(")\n")
+newF.close()
+
+if (os.path.isfile(current_stamp_name)):
+  if (not filecmp.cmp(current_stamp_name, tmp_stamp_name)):
+    os.rename(tmp_stamp_name, current_stamp_name)
+  else:
+    os.remove(tmp_stamp_name)
+else:
+  os.rename(tmp_stamp_name, current_stamp_name)


### PR DESCRIPTION
These changes should allow the make system to rebuild pybind modules whenever a *MOD.py file changes or any of its imported python files.

It works by generating an initial list of dependency files at configuration time that are then checked for changes during the build.