### PR TITLE
Fixing cmake python build with mpicxx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMakeLists to build the Spheral library.
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.10)
 project(spheral LANGUAGES CXX)
 
 include(ExternalProject)

--- a/cmake/spheral/SpheralAddLibs.cmake
+++ b/cmake/spheral/SpheralAddLibs.cmake
@@ -47,18 +47,18 @@ function(spheral_add_cxx_library package_name)
 
   # Install Spheral C++ target and set it as an exportable CMake target
   install(TARGETS             Spheral_${package_name}
-          DESTINATION         Spheral/lib
+          DESTINATION         lib
           EXPORT              ${PROJECT_NAME}-targets
           )
 
   # Install the headers
   install(FILES       ${${package_name}_headers}
-          DESTINATION Spheral/include/${package_name}
+          DESTINATION include/${package_name}
           )
 
   # Set the r-path of the C++ lib such that it is independent of the build dir when installed
   set_target_properties(Spheral_${package_name} PROPERTIES
-                        INSTALL_RPATH           ${CMAKE_INSTALL_PREFIX}/Spheral/lib
+                        INSTALL_RPATH           ${CMAKE_INSTALL_PREFIX}/lib
                         )
 endfunction()
 
@@ -108,7 +108,7 @@ function(spheral_add_pybind11_library package_name)
 
   # Set the r-path of the C++ lib such that it is independent of the build dir when installed
   set_target_properties(${MODULE_NAME} PROPERTIES
-                        INSTALL_RPATH  ${CMAKE_INSTALL_PREFIX}/Spheral/lib
+                        INSTALL_RPATH  ${CMAKE_INSTALL_PREFIX}/lib
                         )
 
 endfunction()

--- a/cmake/tpl/boost.cmake
+++ b/cmake/tpl/boost.cmake
@@ -1,5 +1,7 @@
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
   set(TOOLSET "gcc")
+elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
+  set(TOOLSET "intel-linux")
 else()
   set(TOOLSET ${CMAKE_CXX_COMPILER_ID})
 endif()

--- a/cmake/tpl/python.cmake
+++ b/cmake/tpl/python.cmake
@@ -8,6 +8,24 @@ set(PYTHON_SITE_PACKAGE_DIR ${PYTHON_INSTALL_DIR}/lib/python2.7/site-packages)
 
 set(${lib_name}_INCLUDES $<BUILD_INTERFACE:${PYTHON_INSTALL_DIR}/include/python2.7/>)
 
+set(PYTHON_C_COMPILER ${CMAKE_C_COMPILER})
+set(PYTHON_CXX_COMPILER ${CMAKE_CXX_COMPILER})
+
+if(PYTHON_C_COMPILER MATCHES "mpicc$")
+  execute_process(COMMAND ${CMAKE_C_COMPILER} -show
+                  OUTPUT_VARIABLE MPICC_SHOW )
+  string (REPLACE " " ";" MPICC_SHOW_LIST "${MPICC_SHOW}")
+  list(GET MPICC_SHOW_LIST 0 PYTHON_C_COMPILER)
+  message("${PYTHON_C_COMPILER}")
+endif()
+if(PYTHON_CXX_COMPILER MATCHES "mpicxx$")
+  execute_process(COMMAND ${CMAKE_CXX_COMPILER} -show
+                  OUTPUT_VARIABLE MPICXX_SHOW )
+  string (REPLACE " " ";" MPICXX_SHOW_LIST "${MPICXX_SHOW}")
+  list(GET MPICXX_SHOW_LIST 0 PYTHON_CXX_COMPILER)
+  message("${PYTHON_CXX_COMPILER}")
+endif()
+
 if(${lib_name}_BUILD)
 
   if (EXISTS ${PYTHON_CACHE})
@@ -18,11 +36,11 @@ if(${lib_name}_BUILD)
     PREFIX ${PYTHON_PREFIX}
     URL ${PYTHON_URL} 
     DOWNLOAD_DIR ${CACHE_DIR}
-    CONFIGURE_COMMAND env CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${PYTHON_SRC_DIR}/configure
-                      --with-cxx-main='${CMAKE_CXX_COMPILER}'
+    CONFIGURE_COMMAND env CC=${PYTHON_C_COMPILER} CXX=${PYTHON_CXX_COMPILER} ${PYTHON_SRC_DIR}/configure
+                      --with-cxx-main='${PYTHON_CXX_COMPILER}'
                       --disable-ipv6
                       --prefix=${PYTHON_INSTALL_DIR}
-    BUILD_COMMAND make -j${TPL_PARALLEL_BUILD}
+    BUILD_COMMAND make 
     INSTALL_COMMAND make install
 
     LOG_DOWNLOAD ${OUT_PROTOCOL_EP}


### PR DESCRIPTION
Fixing bug when building python with mpicxx, python tries to add intel flags even when underlying compiler is not icpc.