### PR TITLE
Adding zlib TPL

### DIFF
--- a/cmake/InstallTPLs.cmake
+++ b/cmake/InstallTPLs.cmake
@@ -14,6 +14,7 @@ include(${SPHERAL_ROOT_DIR}/cmake/spheral/SpheralHandleTPL.cmake)
 set(BUILD_TPL ON CACHE BOOL "Define if any TPLs will be built or not.")
 
 # Default build flags for each TPL
+set(zlib_BUILD ON CACHE BOOL "Option to build zlib")
 set(boost_BUILD ON CACHE BOOL "Option to build boost")
 set(eigen_BUILD ON CACHE BOOL "Option to build eigen")
 set(qhull_BUILD ON CACHE BOOL "Option to build qhull")
@@ -28,6 +29,7 @@ set(python_BUILD ON CACHE BOOL "Option to build python")
 set(pip_BUILD ON CACHE BOOL "Option to build pip")
 
 # These libs are always needed
+Spheral_Handle_TPL(zlib spheral_depends)
 Spheral_Handle_TPL(boost spheral_depends)
 Spheral_Handle_TPL(eigen spheral_depends)
 Spheral_Handle_TPL(qhull spheral_depends)

--- a/cmake/InstallTPLs.cmake
+++ b/cmake/InstallTPLs.cmake
@@ -29,12 +29,16 @@ set(python_BUILD ON CACHE BOOL "Option to build python")
 set(pip_BUILD ON CACHE BOOL "Option to build pip")
 
 # These libs are always needed
-Spheral_Handle_TPL(zlib spheral_depends)
 Spheral_Handle_TPL(boost spheral_depends)
 Spheral_Handle_TPL(eigen spheral_depends)
 Spheral_Handle_TPL(qhull spheral_depends)
 Spheral_Handle_TPL(hdf5 spheral_depends)
 Spheral_Handle_TPL(silo spheral_depends)
+
+# Only needed when not building MPI, MPI links it's own zlib.
+if(NOT ENABLE_MPI)
+  Spheral_Handle_TPL(zlib spheral_depends)
+endif()
 
 # Only needed when building the python interface of spheral
 if(NOT ENABLE_CXXONLY)

--- a/cmake/tpl/zlib.cmake
+++ b/cmake/tpl/zlib.cmake
@@ -1,0 +1,31 @@
+set(ZLIB_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${lib_name})
+set(ZLIB_DIST "zlib-1.2.11.tar.gz")
+set(ZLIB_CACHE "${CACHE_DIR}/${ZLIB_DIST}")
+set(ZLIB_URL "http://zlib.net/${ZLIB_DIST}")
+set(ZLIB_SRC_DIR ${ZLIB_PREFIX}/src/zlib)
+
+set(${lib_name}_libs libz.a)
+
+if(${lib_name}_BUILD)
+
+  if (EXISTS ${ZLIB_CACHE})
+    set(ZLIB_URL ${ZLIB_CACHE})
+  endif()
+
+  ExternalProject_add(${lib_name}
+    PREFIX ${ZLIB_PREFIX}
+    URL ${ZLIB_URL} 
+    DOWNLOAD_DIR ${CACHE_DIR}
+    CONFIGURE_COMMAND env CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} CFLAGS=-fpic ${ZLIB_SRC_DIR}/configure
+                      --prefix=${${lib_name}_DIR}
+    BUILD_COMMAND make 
+    INSTALL_COMMAND make install
+
+    LOG_DOWNLOAD ${OUT_PROTOCOL_EP}
+    LOG_CONFIGURE ${OUT_PROTOCOL_EP}
+    LOG_BUILD ${OUT_PROTOCOL_EP}
+    LOG_INSTALL ${OUT_PROTOCOL_EP}
+  )
+
+endif()
+


### PR DESCRIPTION
# Summary
Explicitly adding zlib TPL to fix missing compress2 symbol when MPI=Off

This is necessary because MPI links it's own zlib in, so when compiling without MPI  the zlib `compress2` symbol is undefined.

