### PR TITLE
Wsl2 port

### DIFF
--- a/cmake/tpl/maneos.cmake
+++ b/cmake/tpl/maneos.cmake
@@ -34,4 +34,4 @@ endif()
 
 install(
   FILES ${MANEOS_SRC_DIR}/libaneos.a
-  TYPE LIB)
+  DESTINATION ${MANEOS_DEST_DIR})


### PR DESCRIPTION
This branch is for testing out the build on Windows 10 (Ubuntu).  The only problem I ran into was the version of CMake didn't support the "TYPE LIB" syntax in the install command, so I changed that to "DESTINATION" in the maneos third party lib build.