### PR TITLE
Adding Axom as a TPL

### DIFF
--- a/cmake/InstallTPLs.cmake
+++ b/cmake/InstallTPLs.cmake
@@ -23,6 +23,7 @@ set(hdf5_BUILD ON CACHE BOOL "Option to build hdf5")
 set(silo_BUILD ON CACHE BOOL "Option to build silo")
 set(maneos_BUILD ON CACHE BOOL "Option to build ANEOS")
 set(opensubdiv_BUILD ON CACHE BOOL "Option to build Opensubdiv")
+set(conduit_BUILD ON CACHE BOOL "Option to build Conduit")
 
 set(pybind11_BUILD ON CACHE BOOL "Option to build pybind11")
 set(python_BUILD ON CACHE BOOL "Option to build python")
@@ -35,6 +36,7 @@ Spheral_Handle_TPL(eigen spheral_depends)
 Spheral_Handle_TPL(qhull spheral_depends)
 Spheral_Handle_TPL(hdf5 spheral_depends)
 Spheral_Handle_TPL(silo spheral_depends)
+Spheral_Handle_TPL(conduit spheral_depends)
 
 # Only needed when building the python interface of spheral
 if(NOT ENABLE_CXXONLY)

--- a/cmake/InstallTPLs.cmake
+++ b/cmake/InstallTPLs.cmake
@@ -24,6 +24,7 @@ set(silo_BUILD ON CACHE BOOL "Option to build silo")
 set(maneos_BUILD ON CACHE BOOL "Option to build ANEOS")
 set(opensubdiv_BUILD ON CACHE BOOL "Option to build Opensubdiv")
 set(conduit_BUILD ON CACHE BOOL "Option to build Conduit")
+set(axom_BUILD ON CACHE BOOL "Option to build Axom")
 
 set(pybind11_BUILD ON CACHE BOOL "Option to build pybind11")
 set(python_BUILD ON CACHE BOOL "Option to build python")
@@ -37,6 +38,7 @@ Spheral_Handle_TPL(qhull spheral_depends)
 Spheral_Handle_TPL(hdf5 spheral_depends)
 Spheral_Handle_TPL(silo spheral_depends)
 Spheral_Handle_TPL(conduit spheral_depends)
+Spheral_Handle_TPL(axom spheral_depends)
 
 # Only needed when building the python interface of spheral
 if(NOT ENABLE_CXXONLY)

--- a/cmake/tpl/axom.cmake
+++ b/cmake/tpl/axom.cmake
@@ -1,0 +1,49 @@
+set(AXOM_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${lib_name})
+set(AXOM_DIST "Axom-v0.3.3.tar.gz")
+set(AXOM_URL "https://github.com/LLNL/axom/releases/download/v0.3.3/${AXOM_DIST}")
+set(AXOM_CACHE "${CACHE_DIR}/${AXOM_DIST}")
+
+set(${lib_name}_libs )
+
+if(${lib_name}_BUILD)
+
+  if (EXISTS ${AXOM_CACHE})
+    set(AXOM_URL ${AXOM_CACHE})
+  endif()
+
+  ExternalProject_add(${lib_name}
+    PREFIX ${AXOM_PREFIX}
+    URL ${AXOM_URL}
+    DOWNLOAD_DIR ${CACHE_DIR}
+    CMAKE_ARGS ../axom/src/
+               -DCMAKE_BUILD_TYPE=Release
+               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               -DCMAKE_C_FLAGS=-fPIC
+
+               -DAXOM_ENABLE_TESTS=OFF
+               -DAXOM_ENABLE_EXAMPLES=OFF
+               -DAXOM_ENABLE_DOCS=OFF
+               -DAXOM_ENABLE_INLET=Off
+               -DAXOM_ENABLE_LUMBERJACK=Off
+               -DAXOM_ENABLE_SLAM=Off
+               -DAXOM_ENABLE_MINT=Off
+               -DAXOM_ENABLE_PRIMAL=Off
+               -DAXOM_ENABLE_SPIN=Off
+               -DAXOM_ENABLE_QUEST=Off
+               -DENABLE_TESTS=Off
+
+               -DCONDUIT_DIR=${CONDUIT_INSTALL_DIR}
+               -DHDF5_DIR=${HDF5_INSTALL_DIR}
+
+               -DCMAKE_INSTALL_PREFIX=${${lib_name}_DIR}
+
+    DEPENDS hdf5 conduit
+
+    LOG_DOWNLOAD ${OUT_PROTOCOL_EP}
+    LOG_CONFIGURE ${OUT_PROTOCOL_EP}
+    LOG_BUILD ${OUT_PROTOCOL_EP}
+    LOG_INSTALL ${OUT_PROTOCOL_EP}
+  )
+
+endif()

--- a/cmake/tpl/conduit.cmake
+++ b/cmake/tpl/conduit.cmake
@@ -1,0 +1,30 @@
+set(CONDUIT_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${lib_name})
+set(CONDUIT_DIST "conduit-v0.5.1-src-with-blt.tar.gz")
+set(CONDUIT_URL "https://github.com/LLNL/conduit/releases/download/v0.5.1/${CONDUIT_DIST}")
+set(CONDUIT_CACHE "${CACHE_DIR}/${CONDUIT_DIST}")
+
+set(${lib_name}_libs )
+
+if(${lib_name}_BUILD)
+
+  if (EXISTS ${CONDUIT_CACHE})
+    set(CONDUIT_URL ${CONDUIT_CACHE})
+  endif()
+
+  ExternalProject_add(${lib_name}
+    PREFIX ${CONDUIT_PREFIX}
+    URL ${CONDUIT_URL}
+    DOWNLOAD_DIR ${CACHE_DIR}
+    CMAKE_ARGS ../conduit/src/ -DCMAKE_BUILD_TYPE=Release
+               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               -DCMAKE_C_FLAGS=-fPIC
+               -DENABLE_TESTS=Off
+               -DCMAKE_INSTALL_PREFIX=${${lib_name}_DIR}
+    LOG_DOWNLOAD ${OUT_PROTOCOL_EP}
+    LOG_CONFIGURE ${OUT_PROTOCOL_EP}
+    LOG_BUILD ${OUT_PROTOCOL_EP}
+    LOG_INSTALL ${OUT_PROTOCOL_EP}
+  )
+
+endif()

--- a/cmake/tpl/conduit.cmake
+++ b/cmake/tpl/conduit.cmake
@@ -20,7 +20,11 @@ if(${lib_name}_BUILD)
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                -DCMAKE_C_FLAGS=-fPIC
                -DENABLE_TESTS=Off
+               -DHDF5_DIR=${HDF5_INSTALL_DIR}
                -DCMAKE_INSTALL_PREFIX=${${lib_name}_DIR}
+
+    DEPENDS hdf5
+
     LOG_DOWNLOAD ${OUT_PROTOCOL_EP}
     LOG_CONFIGURE ${OUT_PROTOCOL_EP}
     LOG_BUILD ${OUT_PROTOCOL_EP}
@@ -28,3 +32,4 @@ if(${lib_name}_BUILD)
   )
 
 endif()
+set(CONDUIT_INSTALL_DIR ${${lib_name}_DIR} PARENT_SCOPE)


### PR DESCRIPTION
# Summary

This PR adds Axom as a TPL for use of the Sidre module within Spheral. Conduit is a required TPL for building the Sidre module so this PR also adds Conduit.

A clean build has been performed and all tests have passed.